### PR TITLE
[WIP] Sync the World step to the Scene 

### DIFF
--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -29,6 +29,7 @@
 #include "game.h"
 #include "behavior.h"
 #include "scriptbehavior.h"
+#include "world.h"
 
 #include "box2dworld.h"
 #include "box2dbody.h"
@@ -64,7 +65,7 @@ void Plugins::registerTypes(const char *uri)
     qmlRegisterType<ImageLayer>("Bacon2D", 1, 0, "ImageLayer");
     qmlRegisterType<ScriptBehavior>("Bacon2D", 1, 0, "ScriptBehavior");
 
-    qmlRegisterType<Box2DWorld>("Bacon2D", 1, 0, "World");
+    qmlRegisterType<World>("Bacon2D", 1, 0, "World");
     qmlRegisterType<Box2DBody>("Bacon2D", 1, 0, "Body");
     qmlRegisterUncreatableType<Box2DFixture>("Bacon2D", 1,0, "Fixture",
                                              QStringLiteral("Base type for Box, Circle etc."));
@@ -89,4 +90,5 @@ void Plugins::registerTypes(const char *uri)
     qmlRegisterType<Box2DRopeJoint>("Bacon2D", 1, 0, "RopeJoint");
 
     qmlRegisterUncreatableType<Box2DContact>("Bacon2D", 1,0, "Contact",QStringLiteral("Contact class"));
+    qmlRegisterUncreatableType<Box2DWorld>("Bacon2D", 1,0, "Box2DWorld",QStringLiteral("Box2DWorld class"));
 }

--- a/src/src.pro
+++ b/src/src.pro
@@ -32,7 +32,8 @@ HEADERS += entity.h \
            imagelayer.h \
            enums.h \
            behavior.h \
-           scriptbehavior.h 
+           scriptbehavior.h \
+           world.h
 
 SOURCES += entity.cpp \
            scene.cpp \
@@ -45,7 +46,8 @@ SOURCES += entity.cpp \
            layer.cpp \
            imagelayer.cpp \
            behavior.cpp \
-           scriptbehavior.cpp
+           scriptbehavior.cpp \
+           world.cpp
 
 QMAKE_POST_LINK = $$QMAKE_COPY $$PWD/qmldir $$OUT_PWD/imports/Bacon2D
 

--- a/src/world.cpp
+++ b/src/world.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2014 by Ken VanDine
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @author Ken VanDine <ken@vandine.org>
+ */
+
+#include "world.h"
+
+#include "enums.h"
+
+World::World(Scene *parent)
+    : Box2DWorld(parent)
+    , m_scene(0)
+{
+}
+
+World::~World()
+{
+}
+
+Scene *World::scene() const
+{
+    return m_scene;
+}
+
+void World::setScene(Scene *scene)
+{
+    m_scene = scene;
+}

--- a/src/world.h
+++ b/src/world.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2014 by Ken VanDine
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @author Ken VanDine <ken@vandine.org>
+ */
+
+#ifndef _WORLD_H_
+#define _WORLD_H_
+
+#include "enums.h"
+#include "scene.h"
+
+#include "box2dworld.h"
+
+class World : public Box2DWorld
+{
+    Q_OBJECT
+
+public:
+    World(Scene *parent = 0);
+    ~World();
+
+    Scene *scene() const;
+    void setScene(Scene *scene);
+
+private:
+    Scene *m_scene;
+};
+
+#endif /* _WORLD_H_ */


### PR DESCRIPTION
Set the Box2DWorld's running property to false when it gets added to a Scene.  Rely on the update timer to step the world to keep the entities in the scene and the Box2DWorld in sync.

This branch is a WIP, don't merge yet.  Just looking for feedback.
