### PR TITLE
Ensure viewport content size gets set on geometryChanges

### DIFF
--- a/examples/gamescene/main.qml
+++ b/examples/gamescene/main.qml
@@ -40,8 +40,8 @@ Item {
         Scene {
             id: scene
 
-            width: 300
-            height: 300
+            width: container.width/3
+            height: container.height
 
             function applyLinearImpulse() {
                 var center = Qt.point(x + width / 2, y + height / 2)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -142,8 +142,11 @@ QPointF Game::mouse()
     return window()->mapFromGlobal(QCursor::pos());
 }
 
-void Game::componentComplete()
+void Game::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry)
 {
+    if (newGeometry.isEmpty() || !isComponentComplete() || (newGeometry == oldGeometry))
+        return;
+
     if (m_viewport && m_currentScene) {
         m_viewport->setWidth(width());
         m_viewport->setHeight(height());
@@ -152,5 +155,5 @@ void Game::componentComplete()
         m_viewport->updateMaxOffsets();
     }
 
-    QQuickItem::componentComplete();
+    QQuickItem::geometryChanged(newGeometry, oldGeometry);
 }

--- a/src/game.h
+++ b/src/game.h
@@ -52,9 +52,8 @@ public:
     QString gameName();
     void setGameName(const QString& gameName);
 
-    virtual void componentComplete();
-
 protected:
+    void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry);
     void timerEvent(QTimerEvent *event);
     void update();
 


### PR DESCRIPTION
When the game gets re-sized, geometryChanges the viewport contentHeight and contentWidth should get reset.
