### PR TITLE
Generate plugins.qmltypes

### DIFF
--- a/src/qmldir
+++ b/src/qmldir
@@ -1,2 +1,3 @@
 module Bacon2D
 plugin bacon2dplugin
+typeinfo plugins.qmltypes

--- a/src/src.pro
+++ b/src/src.pro
@@ -60,4 +60,8 @@ qmlpluginfiles.files += \
     $$PWD/qmldir \
     $$OUT_PWD/imports/Bacon2D/*
 
-INSTALLS += target qmlpluginfiles
+qmltypes.path = $$target.path
+qmltypes.extra = $$[QT_INSTALL_BINS]/qmlplugindump -notrelocatable Bacon2D $$API_VER $$OUT_PWD/imports  > $$OUT_PWD/imports/Bacon2D/plugins.qmltypes
+qmltypes.files += $$OUT_PWD/imports/Bacon2D/plugins.qmltypes
+
+INSTALLS += target qmlpluginfiles qmltypes


### PR DESCRIPTION
Generate plugins.qmltypes to fix syntax highlighting and completion in qtcreator
