### PR TITLE
Fixed calculations for contentHeight and contentWidth 

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -112,20 +112,18 @@ void Game::setCurrentScene(Scene *currentScene)
     if (m_currentScene) {
         m_currentScene->setGame(this);
 
-        if ((m_viewport = m_currentScene->viewport())) {
+        if (m_viewport = m_currentScene->viewport()) {
             m_viewport->setParent(this);
             m_viewport->setParentItem(this);
             m_viewport->setScene(m_currentScene);
+            m_currentScene->setParentItem(m_viewport);
             m_viewport->setWidth(width());
             m_viewport->setHeight(height());
             m_viewport->setContentWidth(m_currentScene->width());
             m_viewport->setContentHeight(m_currentScene->height());
             m_viewport->updateMaxOffsets();
             m_viewport->setVisible(true);
-
-            m_currentScene->setParentItem(m_viewport);
         } else {
-            m_currentScene->setParent(this);
             m_currentScene->setParentItem(this);
         }
 


### PR DESCRIPTION
Set currentScene's parent item before calculating contentHeight and contentWidth.
