### PR TITLE
Adjusting README to show how to avoid issue #80

### DIFF
--- a/README
+++ b/README
@@ -36,6 +36,16 @@ $ make
 $ sudo make install
 
 
+*MacOS note*:
+
+If you get some error like 'could not resolve SDK path for...', add 
+'QMAKE_MAC_SDK=MAC_SDK_VERSION'to the qmake command, like this (issue #80):
+
+$ qmake QMAKE_MAC_SDK=macosx10.9 ..
+
+Where MAC_SDK_VERSION points to the OSX version you're using (in the above 
+example it is 10.9.x).
+
 ===========
 2. Examples
 ===========


### PR DESCRIPTION
When building on a MacOS machine, we can get an error about not finding the Mac SDK path. This change adds a note on how to fix it (issue #80).

Special thanks to @ricardodovalle for helping us on it.
