### PR TITLE
game.cpp: add missing #include <QtCore/QCoreApplication>

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -24,6 +24,7 @@
 #include "scene.h"
 #include "viewport.h"
 
+#include <QtCore/QCoreApplication>
 #include <QtQuick/QQuickWindow>
 #include <QtGui/QCursor>
 


### PR DESCRIPTION
It's required to compile under SailfishOS SDK.
