### PR TITLE
Added Bacon2D::State enum and gameState property to Game. 

### DIFF
--- a/examples/contacts/main.qml
+++ b/examples/contacts/main.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.2
 import Bacon2D 1.0
 
-
 Game {
     id: game
     width: 800
@@ -267,7 +266,7 @@ Game {
         Timer {
             id: rectTimer
             interval: 2000
-            running: true
+            running: game.gameState === Bacon2D.Running
             repeat: true
             onTriggered: {
                 var newBox = rectComponent.createObject(scene);

--- a/examples/fixtures/main.qml
+++ b/examples/fixtures/main.qml
@@ -6,6 +6,10 @@ Game {
     width: 800
     height: 600
     currentScene: scene
+    onGameStateChanged: {
+        if (gameState !== Bacon2D.Running)
+            ballsTimer.running = false;
+    }
 
     Component {
         id: ballComponent

--- a/examples/infinitefall/main.qml
+++ b/examples/infinitefall/main.qml
@@ -65,7 +65,7 @@ Game {
             NumberAnimation on rotation {
                 from: 0
                 to: 360
-                running: true
+                running: game.gameState === Bacon2D.Running
                 loops: Animation.Infinite
                 duration: 1800
             }

--- a/examples/layerscroll/main.qml
+++ b/examples/layerscroll/main.qml
@@ -65,7 +65,7 @@ Game {
                 NumberAnimation on rotation {
                     from: 0
                     to: 360
-                    running: true
+                    running: spawnTimer.running
                     loops: Animation.Infinite
                     duration: 1800
                 }
@@ -92,7 +92,7 @@ Game {
             id: spawnTimer
 
             interval: 800
-            running: true
+            running: game.gameState === Bacon2D.Running
             repeat: true
 
             onTriggered: {

--- a/examples/rope/main.qml
+++ b/examples/rope/main.qml
@@ -155,7 +155,7 @@ Game {
         Timer {
             id: ballsTimer
             interval: 500
-            running: true
+            running: game.gameState === Bacon2D.Running
             repeat: true
             onTriggered: {
                 var newBox = linkComponent.createObject(scene);

--- a/examples/sprite/main.qml
+++ b/examples/sprite/main.qml
@@ -39,7 +39,6 @@ Game {
         Sprite {
             id: spriteItem
 
-
             animation: "sliding"
 
             animations: [

--- a/examples/weld/main.qml
+++ b/examples/weld/main.qml
@@ -242,7 +242,7 @@ Game {
         Timer {
             id: ballsTimer
             interval: 1000
-            running: true
+            running: game.gameState === Bacon2D.Running
             repeat: true
             onTriggered: {
                 var newBox = ballComponent.createObject(scene);

--- a/src/Bacon2D-static.pri
+++ b/src/Bacon2D-static.pri
@@ -28,6 +28,7 @@ HEADERS += \
         $$PWD/animationtransition.h \
         $$PWD/behavior.h \
         $$PWD/entity.h \
+        $$PWD/enums.h \
         $$PWD/game.h \
         $$PWD/imagelayer.h \
         $$PWD/imagelayerscrollbehavior.h \
@@ -48,6 +49,7 @@ SOURCES += \
         $$PWD/animationtransition.cpp \
         $$PWD/behavior.cpp \
         $$PWD/entity.cpp \
+        $$PWD/enums.cpp \
         $$PWD/game.cpp \
         $$PWD/imagelayer.cpp \
         $$PWD/imagelayerscrollbehavior.cpp \

--- a/src/enums.cpp
+++ b/src/enums.cpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2014 Bacon2D Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @author Ken VanDine <ken@vandine.org>
+ */
+
+#include "enums.h"
+
+/*!
+  \qmltype State
+  \inqmlmodule Bacon2D
+  \brief This enum type is used to specify the current state of the game.
+  \sa {http://doc.qt.io/qt-5/qt.html#ApplicationState-enum} {Qt.ApplicationState}
+  \table
+  \header
+    \li State
+    \li Description
+  \row
+    \li Bacon2D.Active
+    \li Game is active and the currentScene is not running
+  \row
+    \li Bacon2D.Inactive
+    \li Game is inactive
+  \row
+    \li Bacon2D.Running
+    \li Game is active and the currentScene is running
+  \row
+    \li Bacon2D.Paused
+    \li Game is paused by user request.
+  \row
+    \li Bacon2D.Suspended
+    \li Game is suspended, usually means the platform has stopped the process or the game is no longer focused.
+  \endtable
+*/
+
+Bacon2D::Bacon2D(QObject *parent)
+    : QObject(parent)
+{
+}

--- a/src/enums.h
+++ b/src/enums.h
@@ -1,0 +1,46 @@
+/**
+ * Copyright (C) 2014 Bacon2D Project
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ *
+ * @author Ken VanDine <ken@vandine.org>
+ */
+
+#ifndef _ENUMS_H_
+#define _ENUMS_H_
+
+#include <QObject>
+
+class Bacon2D : public QObject
+{
+    Q_OBJECT
+
+    Q_ENUMS (
+        State
+    )
+
+public:
+    Bacon2D(QObject *parent = 0);
+
+    enum State {
+        Active = 0,
+        Inactive = 1,
+        Running = 2,
+        Paused = 3,
+        Suspended = 4
+    };
+};
+
+#endif /* _ENUMS_H_ */

--- a/src/game.h
+++ b/src/game.h
@@ -23,6 +23,8 @@
 #ifndef _GAME_H_
 #define _GAME_H_
 
+#include "enums.h"
+
 #include <QtQuick/QQuickItem>
 #include <QtCore/QTime>
 #include <QtCore/QtGlobal>
@@ -42,6 +44,7 @@ class Game : public QQuickItem
     Q_PROPERTY(int ups READ ups WRITE setUps NOTIFY upsChanged)
     Q_PROPERTY(QPointF mouse READ mouse)
     Q_PROPERTY(QString gameName READ gameName WRITE setGameName NOTIFY gameNameChanged)
+    Q_PROPERTY(Bacon2D::State gameState READ gameState WRITE setGameState NOTIFY gameStateChanged)
     Q_PROPERTY(int stackLevel READ stackLevel NOTIFY stackLevelChanged)
 
 public:
@@ -62,6 +65,9 @@ public:
     QString gameName();
     void setGameName(const QString& gameName);
 
+    Bacon2D::State gameState() const { return m_state; };
+    void setGameState(const Bacon2D::State &state);
+
 protected:
     void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry);
     void timerEvent(QTimerEvent *event);
@@ -71,6 +77,7 @@ signals:
     void currentSceneChanged();
     void upsChanged();
     void gameNameChanged();
+    void gameStateChanged();
     void stackLevelChanged();
 
 private:
@@ -78,6 +85,7 @@ private:
     QTime m_gameTime;
     int m_ups;
     int m_timerId;
+    Bacon2D::State m_state;
 
     //for handling scene transition
     Scene *m_enterScene;
@@ -95,6 +103,7 @@ private:
 private slots:
     void handleEnterAnimationRunningChanged(bool running);
     void handleExitAnimationRunningChanged(bool running);
+    void onApplicationStateChanged(Qt::ApplicationState state);
 };
 
 #endif /* _GAME_H_ */

--- a/src/plugins.cpp
+++ b/src/plugins.cpp
@@ -23,6 +23,7 @@
 #include "plugins.h"
 
 #include "entity.h"
+#include "enums.h"
 #include "scene.h"
 #include "spriteanimation.h"
 #include "sprite.h"
@@ -59,6 +60,7 @@ void Plugins::registerTypes(const char *uri)
 
     qmlRegisterType<Layer>("Bacon2D", 1, 0, "Layer");
     qmlRegisterUncreatableType<Behavior>("Bacon2D", 1, 0, "Bacon2DBehavior", "Don't use Bacon2DBehavior directly, use one specialized behavior");
+    qmlRegisterUncreatableType<Bacon2D>("Bacon2D", 1, 0, "Bacon2D", "Not creatable as an object, use only to access enums");
 
     qmlRegisterType<Game>("Bacon2D", 1, 0, "Game");
     qmlRegisterType<Scene>("Bacon2D", 1, 0, "Scene");

--- a/src/scene.h
+++ b/src/scene.h
@@ -40,7 +40,7 @@ class Scene : public QQuickItem
 {
     Q_OBJECT
 
-    Q_PROPERTY(bool running READ running WRITE setRunning NOTIFY runningChanged)
+    Q_PROPERTY(bool running READ running NOTIFY runningChanged)
     Q_PROPERTY(Viewport *viewport READ viewport WRITE setViewport NOTIFY viewportChanged)
     Q_PROPERTY(Game *game READ game WRITE setGame)
     Q_PROPERTY(Box2DWorld *world READ world NOTIFY worldChanged)

--- a/src/src.pro
+++ b/src/src.pro
@@ -20,6 +20,7 @@ DEFINES += STATIC_PLUGIN_BOX2D
 include(../3rdparty/qml-box2d/box2d-static.pri)
 
 HEADERS += entity.h \
+           enums.h \
            scene.h \
            game.h \
            plugins.h \
@@ -40,6 +41,7 @@ HEADERS += entity.h \
            settings.h
 
 SOURCES += entity.cpp \
+           enums.cpp \
            scene.cpp \
            game.cpp \
            plugins.cpp \


### PR DESCRIPTION
Added Bacon2D::State enum and gameState property to Game.  Pausing the game should be done by setting Game.gameState to Bacon2D.Paused.  This also listens to Qt.ApplicationState changes and sets Game.gameState to Bacon2D.Suspended if Qt.ApplicationState isn't active and the game isn't paused.  Setting gameState to Paused or Suspended also sets currentScene.running to false.
