### PR TITLE
Sprite::spriteState

### DIFF
--- a/examples/sprite/main.qml
+++ b/examples/sprite/main.qml
@@ -36,11 +36,18 @@ Game {
         width: parent.width
         height: parent.height
 
+        MouseArea {
+            anchors.fill: parent
+
+            onClicked: {
+                spriteItem.spriteState = spriteItem.spriteState == Bacon2D.Running ? Bacon2D.Paused : Bacon2D.Running
+            }
+        }
+
         Sprite {
             id: spriteItem
-
             animation: "sliding"
-
+            spriteState: Bacon2D.Running
             animations: [
                 SpriteAnimation {
                     name: "sliding"
@@ -61,18 +68,16 @@ Game {
                     onFinished: {
                         spriteItem.animation = "sliding"
                     }
-
                 }
             ]
-        }
-    }
 
-    MouseArea {
-        anchors.fill: parent
-
-        onClicked: {
-            spriteItem.animation = spriteItem.animation == "sliding" ? "jumping"
-                                                                     : "sliding"
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    spriteItem.animation = spriteItem.animation == "sliding" ? "jumping"
+                                                                             : "sliding"
+                }
+            }
         }
     }
 }

--- a/src/sprite.h
+++ b/src/sprite.h
@@ -24,10 +24,12 @@
 #define _SPRITE_H_
 
 #include "entity.h"
+#include "enums.h"
 
 #include <QtCore/QHash>
 #include <QtCore/QStateMachine>
 #include <QtQuick/QQuickItem>
+#include <QtCore/QtGlobal>
 
 class Scene;
 class SpriteAnimation;
@@ -35,12 +37,12 @@ class SpriteAnimation;
 class Sprite : public QQuickItem
 {
     Q_OBJECT
-
     Q_PROPERTY(QQmlListProperty<SpriteAnimation> animations READ animations)
     Q_PROPERTY(QString animation READ animation WRITE setAnimation NOTIFY animationChanged)
     Q_PROPERTY(bool verticalMirror READ verticalMirror WRITE setVerticalMirror NOTIFY verticalMirrorChanged)
     Q_PROPERTY(bool horizontalMirror READ horizontalMirror WRITE setHorizontalMirror NOTIFY horizontalMirrorChanged)
     Q_PROPERTY(Entity *entity READ entity WRITE setEntity NOTIFY entityChanged)
+    Q_PROPERTY(Bacon2D::State spriteState READ spriteState WRITE setSpriteState NOTIFY spriteStateChanged)
 
 public:
     Sprite(QQuickItem *parent = 0);
@@ -59,6 +61,9 @@ public:
     Entity *entity() const;
     void setEntity(Entity *entity);
 
+    Bacon2D::State spriteState() const { return m_state; };
+    void setSpriteState(const Bacon2D::State &state);
+
 public slots:
     void initializeAnimation();
 
@@ -67,6 +72,7 @@ signals:
     void verticalMirrorChanged();
     void horizontalMirrorChanged();
     void entityChanged();
+    void spriteStateChanged();
 
 private:
     void initializeMachine();
@@ -81,6 +87,7 @@ private:
     bool m_verticalMirror;
     bool m_horizontalMirror;
     Entity *m_entity;
+    Bacon2D::State m_state;
 };
 
 #endif /* _SPRITE_H_ */

--- a/src/spriteanimation.h
+++ b/src/spriteanimation.h
@@ -39,7 +39,7 @@ class SpriteAnimation : public QState
     Q_PROPERTY(int frames READ frames WRITE setFrames NOTIFY framesChanged)
     Q_PROPERTY(int frame READ frame WRITE setFrame NOTIFY frameChanged)
     Q_PROPERTY(int initialFrame READ initialFrame WRITE setInitialFrame NOTIFY initialFrameChanged)
-    Q_PROPERTY(bool running READ running WRITE setRunning NOTIFY runningChanged)
+    Q_PROPERTY(bool running READ running  NOTIFY runningChanged)
     Q_PROPERTY(int loops READ loops WRITE setLoops NOTIFY loopsChanged)
     Q_PROPERTY(bool visible READ visible WRITE setVisible NOTIFY visibleChanged)
     Q_PROPERTY(int duration READ duration WRITE setDuration NOTIFY durationChanged)


### PR DESCRIPTION
Added spriteState property to Sprite, which is an enum of Bacon2D::State. This makes SpriteAnimation.running a read-only property, which can be controled by setting the spriteState of the Sprite